### PR TITLE
Add Nix Flake and Docker Github Action workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,8 @@ jobs:
           purge-primary-key: never
       - name: "Build Docker image"
         run: nix build .#docker-${{ matrix.arch }}
+      - name: "Login to GHCR"
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: "Load & Push Docker image"
         run: |
           GITHUB_SHA=$(echo ${{ github.sha }} | cut -c 1-7)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
   build:
     name: "Build and Push Docker Image"
     needs: check
+    if: github.ref == 'refs/heads/main'
     strategy:
       matrix:
         arch: ["x86_64-linux", "aarch64-linux"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
     needs: check
     strategy:
       matrix:
-        arch: ["x86_64-linux", "aarch64-linux", "aarch64-darwin"]
+        arch: ["x86_64-linux", "aarch64-linux"]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -66,8 +66,19 @@ jobs:
         run: nix build .#docker-${{ matrix.arch }}
       - name: "Load & Push Docker image"
         run: |
+          GITHUB_SHA=$(echo ${{ github.sha }} | cut -c 1-7)
           ./result | docker load
-          docker tag mst-bot:latest ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-${{ github.sha::0:7 }}
-          docker push ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-${{ github.sha::0:7 }}
-          docker tag mst-bot:latest ghcr.io/falafel72/mst-bot:latest
-          docker push ghcr.io/falafel72/mst-bot:latest
+          SHA_IMAGE_REPO="ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-$GITHUB_SHA
+          LATEST_ARCH_IMAGE_REPO="ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-latest
+          LATEST_IMAGE_REPO="ghcr.io/falafel72/mst-bot:latest"
+          if [[ "${{ matrix.arch }}" == "x86_64-linux" ]]; then
+            ARCH="amd64"
+          else
+            ARCH="arm64"
+          fi
+          docker tag mst-bot:latest $SHA_IMAGE_REPO 
+          docker tag mst-bot:latest $LATEST_ARCH_IMAGE_REPO
+          docker push $SHA_IMAGE_REPO
+          docker push $LATEST_ARCH_IMAGE_REPO
+          docker manifest create $LATEST_IMAGE_REPO $LATEST_ARCH_IMAGE_REPO $LATEST_IMAGE_REPO@$(docker manifest inspect $LATEST_IMAGE_REPO | jq ".manifests[] | select(.platform.architecture != \"$ARCH\") | .digest" | tr -d \")
+          docker manifest push $LATEST_IMAGE_REPO

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,5 +112,5 @@ jobs:
             docker tag "$LATEST_ARCH_IMAGE_REPO" "$LATEST_IMAGE_REPO"
             docker push "$LATEST_IMAGE_REPO"
           fi
-          docker manifest create "$LATEST_IMAGE_REPO" "$LATEST_ARCH_IMAGE_REPO" "ghcr.io/falafel72/mst-bot:x86_64-linux-latest"
+          docker manifest create "$LATEST_IMAGE_REPO" "$LATEST_ARCH_IMAGE_REPO" "$LATEST_IMAGE_REPO"@$(docker manifest inspect "$LATEST_IMAGE_REPO" | jq ".manifests[] | select(.platform.architecture != \"$ARCH\") | .digest" | tr -d \")
           docker manifest push "$LATEST_IMAGE_REPO"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,6 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: "Load & Push Docker image"
         run: |
-          set -x
           GITHUB_SHA=$(echo ${{ github.sha }} | cut -c 1-7)
           ./result | docker load
           SHA_IMAGE_REPO="ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-$GITHUB_SHA"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,9 +108,5 @@ jobs:
           docker tag mst-bot:latest "$LATEST_ARCH_IMAGE_REPO"
           docker push "$SHA_IMAGE_REPO"
           docker push "$LATEST_ARCH_IMAGE_REPO"
-          if ! docker inspect --type=image "$LATEST_IMAGE_REPO"; then
-            docker tag "$LATEST_ARCH_IMAGE_REPO" "$LATEST_IMAGE_REPO"
-            docker push "$LATEST_IMAGE_REPO"
-          fi
-          docker manifest create "$LATEST_IMAGE_REPO" "$LATEST_ARCH_IMAGE_REPO" "ghcr.io/falafel72/mst-bot:x86_64-linux-latest"
+          docker manifest create "$LATEST_IMAGE_REPO" "$LATEST_ARCH_IMAGE_REPO" "$LATEST_IMAGE_REPO"@$(docker manifest inspect "$LATEST_IMAGE_REPO" | jq ".manifests[] | select(.platform.architecture != \"$ARCH\") | .digest" | tr -d \")
           docker manifest push "$LATEST_IMAGE_REPO"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   check:
+    name: "Check Flake"
     strategy:
       matrix:
         arch: ["x86_64-linux", "aarch64-linux"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
   check:
     strategy:
       matrix:
-        arch: ["x86_64-linux", "aarch64-linux", "aarch64-darwin"]
+        arch: ["x86_64-linux", "aarch64-linux"]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,11 +59,8 @@ jobs:
           # if there's no cache hit, restore a cache by this prefix
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 5G
-          purge: true
-          purge-prefixes: nix-${{ runner.os }}-
-          # TTL 1 week
-          purge-created: 604800
-          purge-primary-key: never
+          # Do not purge cache during intermediary step.
+          purge: false
       - name: "Build package"
         run: nix build .#${{ matrix.arch }}
   push-docker:
@@ -88,7 +85,7 @@ jobs:
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
           # TTL 1 week
-          purge-created: 3600
+          purge-created: 604800
           purge-primary-key: never
       - name: "Build Docker image"
         run: nix build .#docker-${{ matrix.arch }}
@@ -96,11 +93,10 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: "Load & Push Docker image"
         run: |
-          set -x
           GITHUB_SHA=$(echo ${{ github.sha }} | cut -c 1-7)
           ./result | docker load
-          SHA_IMAGE_REPO="ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-$GITHUB_SHA
-          LATEST_ARCH_IMAGE_REPO="ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-latest
+          SHA_IMAGE_REPO="ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-$GITHUB_SHA"
+          LATEST_ARCH_IMAGE_REPO="ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-latest"
           LATEST_IMAGE_REPO="ghcr.io/falafel72/mst-bot:latest"
           if [[ "${{ matrix.arch }}" == "x86_64-linux" ]]; then
             ARCH="amd64"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
           purge-primary-key: never
       - name: "Build Docker image"
         run: nix build .#docker-${{ matrix.arch }}
-      - name: "Load Docker image"
+      - name: "Load & Push Docker image"
         run: |
           ./result | docker load
           docker tag mst-bot:latest ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-${{ github.sha::0:7 }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,73 @@
+name: MST-Bot CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  actions: write
+
+env:
+  nix_conf: |
+    keep-env-derivations = true
+    keep-outputs = true
+
+jobs:
+  check:
+    strategy:
+      matrix:
+        arch: ["x86_64-linux", "aarch64-linux", "aarch64-darwin"]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: ${{ env.nix_conf }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          # restore and save a cache using this key
+          primary-key: nix-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          # if there's no cache hit, restore a cache by this prefix
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          # TTL 1 week
+          purge-created: 604800
+          purge-primary-key: never
+      - name: "Run checks"
+        run: nix check .#${{ matrix.arch }}
+  build:
+    name: "Build and Push Docker Image"
+    needs: check
+    strategy:
+      matrix:
+        arch: ["x86_64-linux", "aarch64-linux", "aarch64-darwin"]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: ${{ env.nix_conf }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          # restore and save a cache using this key
+          primary-key: nix-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          # if there's no cache hit, restore a cache by this prefix
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          # TTL 1 week
+          purge-created: 604800
+          purge-primary-key: never
+      - name: "Build Docker image"
+        run: nix build .#docker-${{ matrix.arch }}
+      - name: "Load Docker image"
+        run: |
+          ./result | docker load
+          docker tag mst-bot:latest ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-${{ github.sha::0:7 }}
+          docker push ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-${{ github.sha::0:7 }}
+          docker tag mst-bot:latest ghcr.io/falafel72/mst-bot:latest
+          docker push ghcr.io/falafel72/mst-bot:latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
           # TTL 1 week
-          purge-created: 604800
+          purge-created: 3600
           purge-primary-key: never
       - name: "Build Docker image"
         run: nix build .#docker-${{ matrix.arch }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,11 +38,36 @@ jobs:
           purge-created: 604800
           purge-primary-key: never
       - name: "Run checks"
-        run: nix flake check
+        run: nix flake check --no-build
   build:
-    name: "Build and Push Docker Image"
+    name: "Build"
     needs: check
-    if: github.ref == 'refs/heads/main'
+    strategy:
+      matrix:
+        arch: ["x86_64-linux", "aarch64-linux"]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: ${{ env.nix_conf }}
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          # restore and save a cache using this key
+          primary-key: nix-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          # if there's no cache hit, restore a cache by this prefix
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          # TTL 1 week
+          purge-created: 604800
+          purge-primary-key: never
+      - name: "Build package"
+        run: nix build .#${{ matrix.arch }}
+  push-docker:
+    name: "Push Docker Image"
+    needs: build
     strategy:
       matrix:
         arch: ["x86_64-linux", "aarch64-linux"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,5 +108,9 @@ jobs:
           docker tag mst-bot:latest "$LATEST_ARCH_IMAGE_REPO"
           docker push "$SHA_IMAGE_REPO"
           docker push "$LATEST_ARCH_IMAGE_REPO"
+          if ! docker inspect --type=image "$LATEST_IMAGE_REPO"; then
+            docker tag "$LATEST_ARCH_IMAGE_REPO" "$LATEST_IMAGE_REPO"
+            docker push "$LATEST_IMAGE_REPO"
+          fi
           docker manifest create "$LATEST_IMAGE_REPO" "$LATEST_ARCH_IMAGE_REPO" "$LATEST_IMAGE_REPO"@$(docker manifest inspect "$LATEST_IMAGE_REPO" | jq ".manifests[] | select(.platform.architecture != \"$ARCH\") | .digest" | tr -d \")
           docker manifest push "$LATEST_IMAGE_REPO"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   actions: write
+  packages: write
 
 env:
   nix_conf: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,6 +95,7 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: "Load & Push Docker image"
         run: |
+          set -x
           GITHUB_SHA=$(echo ${{ github.sha }} | cut -c 1-7)
           ./result | docker load
           SHA_IMAGE_REPO="ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-$GITHUB_SHA
@@ -105,9 +106,9 @@ jobs:
           else
             ARCH="arm64"
           fi
-          docker tag mst-bot:latest $SHA_IMAGE_REPO 
-          docker tag mst-bot:latest $LATEST_ARCH_IMAGE_REPO
-          docker push $SHA_IMAGE_REPO
-          docker push $LATEST_ARCH_IMAGE_REPO
-          docker manifest create $LATEST_IMAGE_REPO $LATEST_ARCH_IMAGE_REPO $LATEST_IMAGE_REPO@$(docker manifest inspect $LATEST_IMAGE_REPO | jq ".manifests[] | select(.platform.architecture != \"$ARCH\") | .digest" | tr -d \")
-          docker manifest push $LATEST_IMAGE_REPO
+          docker tag mst-bot:latest "$SHA_IMAGE_REPO"
+          docker tag mst-bot:latest "$LATEST_ARCH_IMAGE_REPO"
+          docker push "$SHA_IMAGE_REPO"
+          docker push "$LATEST_ARCH_IMAGE_REPO"
+          docker manifest create "$LATEST_IMAGE_REPO" "$LATEST_ARCH_IMAGE_REPO" "$LATEST_IMAGE_REPO"@$(docker manifest inspect "$LATEST_IMAGE_REPO" | jq ".manifests[] | select(.platform.architecture != \"$ARCH\") | .digest" | tr -d \")
+          docker manifest push "$LATEST_IMAGE_REPO"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,7 @@ jobs:
   push-docker:
     name: "Push Docker Image"
     needs: build
+    if: github.ref == 'refs/heads/main'
     strategy:
       matrix:
         arch: ["x86_64-linux", "aarch64-linux"]
@@ -105,6 +106,7 @@ jobs:
   set-docker-tags:
     name: "Set Docker Image Manifests"
     needs: push-docker
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
           purge-created: 604800
           purge-primary-key: never
       - name: "Run checks"
-        run: nix check .#${{ matrix.arch }}
+        run: nix flake check
   build:
     name: "Build and Push Docker Image"
     needs: check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,6 +93,7 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: "Load & Push Docker image"
         run: |
+          set -x
           GITHUB_SHA=$(echo ${{ github.sha }} | cut -c 1-7)
           ./result | docker load
           SHA_IMAGE_REPO="ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-$GITHUB_SHA"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,5 +112,5 @@ jobs:
             docker tag "$LATEST_ARCH_IMAGE_REPO" "$LATEST_IMAGE_REPO"
             docker push "$LATEST_IMAGE_REPO"
           fi
-          docker manifest create "$LATEST_IMAGE_REPO" "$LATEST_ARCH_IMAGE_REPO" "$LATEST_IMAGE_REPO"@$(docker manifest inspect "$LATEST_IMAGE_REPO" | jq ".manifests[] | select(.platform.architecture != \"$ARCH\") | .digest" | tr -d \")
+          docker manifest create "$LATEST_IMAGE_REPO" "$LATEST_ARCH_IMAGE_REPO" "ghcr.io/falafel72/mst-bot:x86_64-linux-latest"
           docker manifest push "$LATEST_IMAGE_REPO"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,8 @@ jobs:
           gc-max-store-size-linux: 5G
           purge: true
           purge-prefixes: nix-${{ runner.os }}-
+          # Do not override the build cache
+          save: false
           # TTL 1 week
           purge-created: 604800
           purge-primary-key: never

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,14 +98,19 @@ jobs:
           SHA_IMAGE_REPO="ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-$GITHUB_SHA"
           LATEST_ARCH_IMAGE_REPO="ghcr.io/falafel72/mst-bot:${{ matrix.arch }}-latest"
           LATEST_IMAGE_REPO="ghcr.io/falafel72/mst-bot:latest"
-          if [[ "${{ matrix.arch }}" == "x86_64-linux" ]]; then
-            ARCH="amd64"
-          else
-            ARCH="arm64"
-          fi
           docker tag mst-bot:latest "$SHA_IMAGE_REPO"
           docker tag mst-bot:latest "$LATEST_ARCH_IMAGE_REPO"
           docker push "$SHA_IMAGE_REPO"
           docker push "$LATEST_ARCH_IMAGE_REPO"
-          docker manifest create "$LATEST_IMAGE_REPO" "$LATEST_ARCH_IMAGE_REPO" "$LATEST_IMAGE_REPO"@$(docker manifest inspect "$LATEST_IMAGE_REPO" | jq ".manifests[] | select(.platform.architecture != \"$ARCH\") | .digest" | tr -d \")
-          docker manifest push "$LATEST_IMAGE_REPO"
+  set-docker-tags:
+    name: "Set Docker Image Manifests"
+    needs: push-docker
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Login to GHCR"
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: "Setup latest image manifest"
+        run: |
+          docker manifest create "ghcr.io/falafel72/mst-bot:latest" "ghcr.io/falafel72/mst-bot:x86_64-linux-latest" "ghcr.io/falafel72/mst-bot:aarch64-linux-latest"
+          docker manifest push "ghcr.io/falafel72/mst-bot:latest"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+result

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 result
+database.db
+.env

--- a/.sqlx/query-302c2bd4b2a216dc6dc5ce5b9e5c7dc8b875895907247fd0479ec9583fcabea5.json
+++ b/.sqlx/query-302c2bd4b2a216dc6dc5ce5b9e5c7dc8b875895907247fd0479ec9583fcabea5.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT datetime_unix FROM meetups WHERE user_id = ? AND guild_id = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "datetime_unix",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "302c2bd4b2a216dc6dc5ce5b9e5c7dc8b875895907247fd0479ec9583fcabea5"
+}

--- a/.sqlx/query-32eb008cb4ac1bbe4ff0723274a2be58b8c2f55e6b711153e13a45cc548fcf99.json
+++ b/.sqlx/query-32eb008cb4ac1bbe4ff0723274a2be58b8c2f55e6b711153e13a45cc548fcf99.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT * FROM delays WHERE user_id = ? AND (guild_id = ? OR guild_id IS NULL)",
+  "describe": {
+    "columns": [
+      {
+        "name": "user_id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "delay_seconds",
+        "ordinal": 1,
+        "type_info": "Integer"
+      },
+      {
+        "name": "guild_id",
+        "ordinal": 2,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "32eb008cb4ac1bbe4ff0723274a2be58b8c2f55e6b711153e13a45cc548fcf99"
+}

--- a/.sqlx/query-3f8eca86dbe6eab7cb86906e8bd51a95a5ce846ef664d48483bd94d7c4832f0b.json
+++ b/.sqlx/query-3f8eca86dbe6eab7cb86906e8bd51a95a5ce846ef664d48483bd94d7c4832f0b.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO meetups (user_id, datetime_unix, guild_id) VALUES (?, ?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "3f8eca86dbe6eab7cb86906e8bd51a95a5ce846ef664d48483bd94d7c4832f0b"
+}

--- a/.sqlx/query-7e95347e5a6ba0a293ff504d4ee913fede5b76396ce3660d30922f8ce04e19ff.json
+++ b/.sqlx/query-7e95347e5a6ba0a293ff504d4ee913fede5b76396ce3660d30922f8ce04e19ff.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT datetime_unix FROM meetups WHERE user_id = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "datetime_unix",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "7e95347e5a6ba0a293ff504d4ee913fede5b76396ce3660d30922f8ce04e19ff"
+}

--- a/.sqlx/query-889788db82d68ebd004fae20e8c7470621ecc265d918fa5da101e95415e0a31c.json
+++ b/.sqlx/query-889788db82d68ebd004fae20e8c7470621ecc265d918fa5da101e95415e0a31c.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO delays (user_id, delay_seconds, guild_id) VALUES (?, ?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "889788db82d68ebd004fae20e8c7470621ecc265d918fa5da101e95415e0a31c"
+}

--- a/.sqlx/query-efb1f241fca84d9bfbb52dc40f4d0be08863d8f0b3d2be6e4fc51c11c46347a8.json
+++ b/.sqlx/query-efb1f241fca84d9bfbb52dc40f4d0be08863d8f0b3d2be6e4fc51c11c46347a8.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM meetups WHERE user_id = ? AND guild_id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "efb1f241fca84d9bfbb52dc40f4d0be08863d8f0b3d2be6e4fc51c11c46347a8"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM lukemathwalker/cargo-chef:latest AS chef
+RUN cargo install sqlx-cli
 WORKDIR /app
 
 FROM chef AS planner
@@ -9,7 +10,9 @@ FROM chef AS builder
 COPY --from=planner /app/recipe.json .
 RUN cargo chef cook --release
 COPY . .
-ENV SQLX_OFFLINE=true
+ENV DATABASE_URL=sqlite:./database.db
+RUN sqlx database create
+RUN sqlx migrate run
 RUN cargo build --release
 RUN mv ./target/release/mst-bot ./app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM lukemathwalker/cargo-chef:latest AS chef
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json .
+RUN cargo chef cook --release
+COPY . .
+ENV SQLX_OFFLINE=true
+RUN cargo build --release
+RUN mv ./target/release/mst-bot ./app
+
+FROM debian:stable-slim AS runtime
+WORKDIR /app
+COPY --from=builder /app/app /usr/local/bin/
+ENTRYPOINT ["/usr/local/bin/app"]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1742143293,
+        "narHash": "sha256-8oKPsMlqlOQ7qnTWvhBEcfVFY1WqHIcSilGVtaLAquw=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "de3bb0155823298161c1c0a7805f10d4b4074bbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1742206328,
+        "narHash": "sha256-q+AQ///oMnyyFzzF4H9ShSRENt3Zsx37jTiRkLkXXE0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "096478927c360bc18ea80c8274f013709cf7bdcd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742265167,
+        "narHash": "sha256-RB0UEF9IXIgwuuBFC+s9H4rDyvmMZePHlBAK4vRAwf4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "87f0965f9f5b13fca9f38074eee8369dc767550d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -92,7 +92,10 @@
         # Filter the available cross-compilation system for x86_64-linux and aarch64-linux
         # to exclude macOS packages. Unfortunately, certain libraries are unavailable when
         # cross-compiling for macOS.
-        availableSystems = if localSystem != "aarch64-darwin" then builtins.filter (x: x != "aarch64-darwin") systemsToBuildFor else systemsToBuildFor;
+        availableSystems =
+          if localSystem != "aarch64-darwin"
+          then builtins.filter (x: x != "aarch64-darwin") systemsToBuildFor
+          else systemsToBuildFor;
         cranePackages = lib.attrsets.genAttrs availableSystems (system: generateCranePackage system);
         dockerImagesForSystem =
           map (crossSystem: let
@@ -105,7 +108,15 @@
             value = pkgs.pkgsHostHost.dockerTools.streamLayeredImage {
               name = "mst-bot";
               tag = "latest";
-              contents = with pkgs.pkgsHostHost; [cranePackages."${crossSystem}" cacert];
+              contents = with pkgs.pkgsHostHost; [
+                cranePackages."${crossSystem}"
+                cacert
+                (pkgs.buildEnv
+                {
+                  name = "mst-bot-migrations";
+                  paths = [./migrations];
+                })
+              ];
               config = {
                 Cmd = ["${cranePackages."${crossSystem}"}/bin/mst-bot"];
               };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,99 @@
+{
+  description = "A Discord bot tracking the delay of certain tardy friends joining a Discord call.";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    crane.url = "github:ipetkov/crane";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+  outputs = { nixpkgs, crane, flake-utils, rust-overlay, ... }:
+    flake-utils.lib.eachDefaultSystem (localSystem:
+      let
+        systemsToBuildFor = ["x86_64-linux" "aarch64-linux"];
+        # Attribute set of all targets to compile for.
+        # This will be referenced in outputs when we define what target we want.
+        # targetPkgs = lib.attrsets.genAttrs systemsToBuildFor (target:
+        #   import nixpkgs {
+        #     crossSystem = target;
+        #     inherit localSystem;
+        #     overlays = [ (import rust-overlay ) ];
+        #   };
+        # );
+        pkgs = import nixpkgs {
+          inherit localSystem;
+          crossSystem = "x86_64-linux";
+          overlays = [ (import rust-overlay ) ];
+        };
+
+        # Pin Rust toolchain via overlay.
+        rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+        # Setup Crane functions with pinned toolchain in project.
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+        # Separate out the migrations to use later
+        # for the SQLx CLI setup.
+        unfilteredRoot = ./.;
+        src = lib.fileset.toSource {
+          root = unfilteredRoot;
+          fileset = lib.fileset.unions [
+            (craneLib.fileset.commonCargoSources unfilteredRoot)
+            ./migrations
+          ];
+        };
+
+        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+        mst-bot-crate = craneLib.buildPackage (commonArgs // {
+          inherit cargoArtifacts;
+          nativeBuildInputs = (commonArgs.nativeBuildInputs ++ [
+            pkgs.sqlx-cli
+          ]);
+          pre-build = ''
+            export DATABASE_URL=sqlite:./database.db
+            sqlx database create
+            sqlx migrate run
+          '';
+        });
+
+
+        crateExpression =
+        {
+            openssl,
+            darwin,
+            libiconv,
+            lib,
+            pkg-config,
+            stdenv,
+        }:
+        let
+          commonArgs = {
+            inherit src;
+            strictDeps = true;
+
+            nativeBuildInputs = [
+              pkg-config
+            ];
+
+            buildInputs = [
+              openssl
+            ] ++ lib.optionals pkgs.stdenv.isDarwin [
+              # Hacky macOS dependencies. Wonderful.
+              libiconv
+              darwin.apple_sdk.frameworks.Security
+            ];
+          };
+        in
+        craneLib.buildPackage {
+          inherit src;
+          strictDeps = true;
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.buildPlatform.isDarwin [ libiconv ];
+          buildInputs = [ openssl ];
+        };
+        
+      in 
+    )
+}

--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,7 @@
           };
 
         devShells.default = craneLib.devShell {
-          checks = self.checks.${localSystem};
+          checks = self.checks;
           packages = with pkgs; [
             sqlx-cli
             ripgrep

--- a/flake.nix
+++ b/flake.nix
@@ -89,7 +89,11 @@
                 '';
               })
         );
-        cranePackages = lib.attrsets.genAttrs systemsToBuildFor (system: generateCranePackage system);
+        # Filter the available cross-compilation system for x86_64-linux and aarch64-linux
+        # to exclude macOS packages. Unfortunately, certain libraries are unavailable when
+        # cross-compiling for macOS.
+        availableSystems = if localSystem != "aarch64-darwin" then builtins.filter (x: x != "aarch64-darwin") systemsToBuildFor else systemsToBuildFor;
+        cranePackages = lib.attrsets.genAttrs availableSystems (system: generateCranePackage system);
         dockerImagesForSystem =
           map (crossSystem: let
             pkgs = import nixpkgs {
@@ -107,7 +111,7 @@
               };
             };
           })
-          systemsToBuildFor;
+          availableSystems;
         dockerImages = builtins.listToAttrs dockerImagesForSystem;
       in {
         checks =

--- a/flake.nix
+++ b/flake.nix
@@ -90,14 +90,38 @@
               })
         );
         cranePackages = lib.attrsets.genAttrs systemsToBuildFor (system: generateCranePackage system);
+        dockerImagesForSystem =
+          map (crossSystem: let
+            pkgs = import nixpkgs {
+              inherit localSystem crossSystem;
+              overlays = [(import rust-overlay)];
+            };
+          in {
+            name = "docker-${crossSystem}";
+            value = pkgs.pkgsHostHost.dockerTools.streamLayeredImage {
+              name = "mst-bot";
+              tag = "latest";
+              contents = with pkgs.pkgsHostHost; [cranePackages."${crossSystem}" cacert];
+              config = {
+                Cmd = ["${cranePackages."${crossSystem}"}/bin/mst-bot"];
+              };
+            };
+          })
+          systemsToBuildFor;
+        dockerImages = builtins.listToAttrs dockerImagesForSystem;
       in {
-        checks = cranePackages // {
-          default = cranePackages."${localSystem}";
-        };
+        checks =
+          cranePackages
+          // {
+            default = cranePackages."${localSystem}";
+          };
 
-        packages = cranePackages // {
-          default = cranePackages."${localSystem}";
-        };
+        packages =
+          cranePackages
+          // dockerImages
+          // {
+            default = cranePackages."${localSystem}";
+          };
 
         devShells.default = craneLib.devShell {
           checks = self.checks.${localSystem};

--- a/flake.nix
+++ b/flake.nix
@@ -9,91 +9,104 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
-  outputs = { nixpkgs, crane, flake-utils, rust-overlay, ... }:
-    flake-utils.lib.eachDefaultSystem (localSystem:
-      let
-        systemsToBuildFor = ["x86_64-linux" "aarch64-linux"];
-        # Attribute set of all targets to compile for.
-        # This will be referenced in outputs when we define what target we want.
-        # targetPkgs = lib.attrsets.genAttrs systemsToBuildFor (target:
-        #   import nixpkgs {
-        #     crossSystem = target;
-        #     inherit localSystem;
-        #     overlays = [ (import rust-overlay ) ];
-        #   };
-        # );
+  outputs = {
+    self,
+    nixpkgs,
+    crane,
+    flake-utils,
+    rust-overlay,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      localSystem: let
+        systemsToBuildFor = ["x86_64-linux" "aarch64-linux" "aarch64-darwin"];
         pkgs = import nixpkgs {
           inherit localSystem;
-          crossSystem = "x86_64-linux";
-          overlays = [ (import rust-overlay ) ];
+          overlays = [(import rust-overlay)];
         };
-
         # Pin Rust toolchain via overlay.
         rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        inherit (pkgs) lib;
 
         # Setup Crane functions with pinned toolchain in project.
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
-        # Separate out the migrations to use later
-        # for the SQLx CLI setup.
-        unfilteredRoot = ./.;
-        src = lib.fileset.toSource {
-          root = unfilteredRoot;
-          fileset = lib.fileset.unions [
-            (craneLib.fileset.commonCargoSources unfilteredRoot)
-            ./migrations
+        # Function to generate the relevant Crane package for the system target selected.
+        #
+        # This lets us eventually generate one crane package for each cross-compilation build
+        # we're doing.
+        generateCranePackage = (
+          crossSystem: let
+            pkgs = import nixpkgs {
+              inherit localSystem crossSystem;
+              overlays = [(import rust-overlay)];
+            };
+            inherit (pkgs) lib;
+
+            # Setup Crane functions with pinned toolchain in project.
+            craneLib = (crane.mkLib pkgs).overrideToolchain (p: p.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml);
+
+            # Separate out the migrations to use later
+            # for the SQLx CLI setup.
+            unfilteredRoot = ./.;
+            src = lib.fileset.toSource {
+              root = unfilteredRoot;
+              fileset = lib.fileset.unions [
+                (craneLib.fileset.commonCargoSources unfilteredRoot)
+                ./migrations
+              ];
+            };
+
+            commonArgs = {
+              inherit src;
+              strictDeps = true;
+              nativeBuildInputs = with pkgs.pkgsBuildHost; [
+                pkg-config
+              ];
+              buildInputs = with pkgs.pkgsHostHost;
+                [
+                  openssl
+                ]
+                ++ lib.optionals stdenv.isDarwin [
+                  libiconv
+                  darwin.apple_sdk.frameworks.Security
+                ];
+            };
+            cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          in
+            craneLib.buildPackage (commonArgs
+              // {
+                inherit cargoArtifacts;
+                nativeBuildInputs =
+                  (commonArgs.nativeBuildInputs or [])
+                  ++ [
+                    pkgs.pkgsBuildHost.sqlx-cli
+                  ];
+                preBuild = ''
+                  export DATABASE_URL=sqlite:./database.db
+                  sqlx database create
+                  sqlx migrate run
+                '';
+              })
+        );
+        cranePackages = lib.attrsets.genAttrs systemsToBuildFor (system: generateCranePackage system);
+      in {
+        checks = cranePackages // {
+          default = cranePackages."${localSystem}";
+        };
+
+        packages = cranePackages // {
+          default = cranePackages."${localSystem}";
+        };
+
+        devShells.default = craneLib.devShell {
+          checks = self.checks.${localSystem};
+          packages = with pkgs; [
+            sqlx-cli
+            ripgrep
+            fd
           ];
         };
-
-        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-        mst-bot-crate = craneLib.buildPackage (commonArgs // {
-          inherit cargoArtifacts;
-          nativeBuildInputs = (commonArgs.nativeBuildInputs ++ [
-            pkgs.sqlx-cli
-          ]);
-          pre-build = ''
-            export DATABASE_URL=sqlite:./database.db
-            sqlx database create
-            sqlx migrate run
-          '';
-        });
-
-
-        crateExpression =
-        {
-            openssl,
-            darwin,
-            libiconv,
-            lib,
-            pkg-config,
-            stdenv,
-        }:
-        let
-          commonArgs = {
-            inherit src;
-            strictDeps = true;
-
-            nativeBuildInputs = [
-              pkg-config
-            ];
-
-            buildInputs = [
-              openssl
-            ] ++ lib.optionals pkgs.stdenv.isDarwin [
-              # Hacky macOS dependencies. Wonderful.
-              libiconv
-              darwin.apple_sdk.frameworks.Security
-            ];
-          };
-        in
-        craneLib.buildPackage {
-          inherit src;
-          strictDeps = true;
-          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-          nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.buildPlatform.isDarwin [ libiconv ];
-          buildInputs = [ openssl ];
-        };
-        
-      in 
-    )
+      }
+    );
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+targets = [ "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,7 @@
 [toolchain]
 channel = "stable"
-targets = [ "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu" ]
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-gnu",
+  "aarch64-apple-darwin",
+]


### PR DESCRIPTION
This PR adds a Nix flake for easy reproducible compilation and for the quick creation of slim Docker images. I also included a Github Action workflow to compile the image and add it to GHCR.

A useful future addition is setting up a Github action to garbage-collect older GHCR images, as we don't need to store all of them.

Note that Nix cannot build Docker images on macOS. In lieu of this, a simple (moderately slim) Dockerfile is provided. The Dockerfile image output is slightly larger than the Docker image created by Nix, but moderately equivalent.