### PR TITLE
Add tzdata to Docker image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,7 @@
               contents = with pkgs.pkgsHostHost; [
                 cranePackages."${crossSystem}"
                 cacert
+                tzdata
               ];
               config = {
                 Cmd = ["${cranePackages."${crossSystem}"}/bin/mst-bot"];


### PR DESCRIPTION
We need this to enable using local timezones in the Docker image.

Hopefully setting the `TZ` environment variable is enough,